### PR TITLE
Actualizar links docusaurus en el README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 `Instalar el Backend`
 
-Toda la información sobre la instalación del backend se puede encontrar en nuesta [documentación sobre como instalar el Backend](https://ispp-knot.github.io/knot/docs/guia-de-instalacion/instalacion-backend)
+Toda la información sobre la instalación del backend se puede encontrar en nuesta [documentación sobre como instalar el Backend](https://ispp-knot.github.io/internal-documentation/docs/guia-de-instalacion/instalacion-backend)
 
 `Detalles adicionales`
 
 Para saber acerca de detalles del desarrollo, acceder a cualquiera de los enlaces de interes:
 
-- [Guía de estilo](https://ispp-knot.github.io/knot/docs/guia-de-desarrollo/estilos-de-codigo)
-- [Como contribuir en Github](https://ispp-knot.github.io/knot/docs/guia-de-desarrollo/contribuir-github)
-- [La arquitectura de Spring](https://ispp-knot.github.io/knot/docs/guia-de-desarrollo/arquitectura-spring)
-- [El linting automatico](https://ispp-knot.github.io/knot/docs/guia-de-desarrollo/lint)
-- [Migraciones](https://ispp-knot.github.io/knot/docs/guia-de-desarrollo/migraciones)
-- [Testing](https://ispp-knot.github.io/knot/docs/guia-de-desarrollo/migraciones)
+- [Guía de estilo](https://ispp-knot.github.io/internal-documentation/docs/guia-de-desarrollo/estilos-de-codigo)
+- [Como contribuir en Github](https://ispp-knot.github.io/internal-documentation/docs/guia-de-desarrollo/contribuir-github)
+- [La arquitectura de Spring](https://ispp-knot.github.io/internal-documentation/docs/guia-de-desarrollo/backend)
+- [El linting automatico](https://ispp-knot.github.io/internal-documentation/docs/guia-de-desarrollo/lint)
+- [Migraciones](https://ispp-knot.github.io/internal-documentation/docs/guia-de-desarrollo/migraciones)
+- [Testing](https://ispp-knot.github.io/internal-documentation/docs/guia-de-desarrollo/migraciones)
 
 `Frontend`
 
-Si se quiere acceder a la [información del frontend](https://ispp-knot.github.io/knot/docs/guia-de-instalacion/instalacion-frontend)
+Si se quiere acceder a la [información del frontend](https://ispp-knot.github.io/internal-documentation/docs/guia-de-instalacion/instalacion-frontend)
 
 Si se quiere acceder al [repositorio del frontend](https://github.com/ispp-knot/dondesiempre-frontend)


### PR DESCRIPTION
# Backend Pull Request

## Description

Los links apuntaban a la antigua url del docusaurus, ahora apuntan al actual.

---

## Type of Change

- [ ] New endpoint
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Database Changes (if applicable)

Nada

---

## Checklist

- [x] I made sure tests are passing locally
- [x] I handled error cases
- [x] I followed the style guides
- [x] I followed the Controller-Service-Repository pattern
- [x] I tested my code
