### PR TITLE
Fix/social network restriction

### DIFF
--- a/src/main/java/ispp/project/dondesiempre/config/GlobalExceptionHandler.java
+++ b/src/main/java/ispp/project/dondesiempre/config/GlobalExceptionHandler.java
@@ -2,11 +2,6 @@ package ispp.project.dondesiempre.config;
 
 import com.stripe.exception.StripeException;
 import ispp.project.dondesiempre.modules.common.exceptions.*;
-import ispp.project.dondesiempre.modules.common.exceptions.AlreadyExistsException;
-import ispp.project.dondesiempre.modules.common.exceptions.InvalidBoundingBoxException;
-import ispp.project.dondesiempre.modules.common.exceptions.InvalidRequestException;
-import ispp.project.dondesiempre.modules.common.exceptions.ResourceNotFoundException;
-import ispp.project.dondesiempre.modules.common.exceptions.UnauthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -82,5 +77,12 @@ public class GlobalExceptionHandler {
   public ResponseEntity<String> handleLimitExceededException(
       LimitExceededException exception, WebRequest request) {
     return new ResponseEntity<>(exception.getMessage(), HttpStatus.UNAUTHORIZED);
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(InvalidSocialNetworkException.class)
+  public ResponseEntity<String> handleInvalidSocialNetworkException(
+      InvalidSocialNetworkException exception, WebRequest request) {
+    return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/main/java/ispp/project/dondesiempre/modules/common/exceptions/InvalidSocialNetworkException.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/common/exceptions/InvalidSocialNetworkException.java
@@ -1,0 +1,7 @@
+package ispp.project.dondesiempre.modules.common.exceptions;
+
+public class InvalidSocialNetworkException extends RuntimeException {
+  public InvalidSocialNetworkException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkService.java
@@ -40,14 +40,15 @@ public class StoreSocialNetworkService {
     String clean = link.replaceAll("\\s+", "");
     String nameLower = name.toLowerCase();
 
+    String phoneDigits = clean.startsWith("tel:") ? clean.replace("tel:", "") : clean;
+
     if (PHONE_NETWORKS.contains(name)) {
-      String phoneDigits = clean.startsWith("tel:") ? clean.replace("tel:", "") : clean;
       if (!phoneDigits.matches(PHONE_REGEX)) {
         throw new InvalidSocialNetworkException(
             "Must be a valid telephone number, formed by 9-15 digits, prefix allowed.");
       }
     } else {
-      boolean isWhatsappPhone = nameLower.equals("whatsapp") && clean.matches(PHONE_REGEX);
+      boolean isWhatsappPhone = nameLower.equals("whatsapp") && phoneDigits.matches(PHONE_REGEX);
 
       if (!isWhatsappPhone && !link.matches(URL_REGEX)) {
         throw new InvalidSocialNetworkException("Must be a valid URL.");
@@ -57,7 +58,7 @@ public class StoreSocialNetworkService {
 
       switch (nameLower) {
         case "instagram":
-          if (!linkLower.matches("^(https?://)?(www\\.)?instagram\\.com(/.*)?$")) {
+          if (!linkLower.matches("^(https?://)?(www\\.)?(instagram\\.com|ig\\.me)(/.*)?$")) {
             throw new InvalidSocialNetworkException("Link must be a valid Instagram URL.");
           }
           break;

--- a/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkService.java
@@ -2,6 +2,7 @@ package ispp.project.dondesiempre.modules.stores.services;
 
 import ispp.project.dondesiempre.modules.auth.services.AuthService;
 import ispp.project.dondesiempre.modules.common.exceptions.AlreadyExistsException;
+import ispp.project.dondesiempre.modules.common.exceptions.InvalidSocialNetworkException;
 import ispp.project.dondesiempre.modules.common.exceptions.ResourceNotFoundException;
 import ispp.project.dondesiempre.modules.common.exceptions.UnauthorizedException;
 import ispp.project.dondesiempre.modules.stores.dtos.SocialNetworkDTO;
@@ -35,52 +36,51 @@ public class StoreSocialNetworkService {
 
   private static final Set<String> PHONE_NETWORKS = Set.of("Teléfono", "Phone");
 
-  private void validateByNetwork(String name, String link) {
+  private void validateByNetwork(String name, String link) throws InvalidSocialNetworkException {
     String clean = link.replaceAll("\\s+", "");
     String nameLower = name.toLowerCase();
 
     if (PHONE_NETWORKS.contains(name)) {
       String phoneDigits = clean.startsWith("tel:") ? clean.replace("tel:", "") : clean;
       if (!phoneDigits.matches(PHONE_REGEX)) {
-        throw new IllegalArgumentException(
+        throw new InvalidSocialNetworkException(
             "Must be a valid telephone number, formed by 9-15 digits, prefix allowed.");
       }
     } else {
       boolean isWhatsappPhone = nameLower.equals("whatsapp") && clean.matches(PHONE_REGEX);
 
       if (!isWhatsappPhone && !link.matches(URL_REGEX)) {
-        throw new IllegalArgumentException("Must be a valid URL.");
+        throw new InvalidSocialNetworkException("Must be a valid URL.");
       }
 
       String linkLower = link.toLowerCase();
 
       switch (nameLower) {
         case "instagram":
-          if (!linkLower.contains("instagram.com")) {
-            throw new IllegalArgumentException("Link must be a valid Instagram URL.");
+          if (!linkLower.matches("^(https?://)?(www\\.)?instagram\\.com(/.*)?$")) {
+            throw new InvalidSocialNetworkException("Link must be a valid Instagram URL.");
           }
           break;
         case "tiktok":
-          if (!linkLower.contains("tiktok.com")) {
-            throw new IllegalArgumentException("Link must be a valid TikTok URL.");
+          if (!linkLower.matches("^(https?://)?(www\\.)?tiktok\\.com(/.*)?$")) {
+            throw new InvalidSocialNetworkException("Link must be a valid TikTok URL.");
           }
           break;
         case "facebook":
-          if (!linkLower.contains("facebook.com")) {
-            throw new IllegalArgumentException("Link must be a valid Facebook URL.");
+          if (!linkLower.matches("^(https?://)?(www\\.)?facebook\\.com(/.*)?$")) {
+            throw new InvalidSocialNetworkException("Link must be a valid Facebook URL.");
           }
           break;
         case "x":
         case "twitter":
-          if (!linkLower.contains("x.com") && !linkLower.contains("twitter.com")) {
-            throw new IllegalArgumentException("Link must be a valid X/Twitter URL.");
+          if (!linkLower.matches("^(https?://)?(www\\.)?(x\\.com|twitter\\.com)(/.*)?$")) {
+            throw new InvalidSocialNetworkException("Link must be a valid X/Twitter URL.");
           }
           break;
         case "whatsapp":
           if (!isWhatsappPhone
-              && !linkLower.contains("wa.me")
-              && !linkLower.contains("whatsapp.com")) {
-            throw new IllegalArgumentException(
+              && !linkLower.matches("^(https?://)?(www\\.)?(wa\\.me|whatsapp\\.com)(/.*)?$")) {
+            throw new InvalidSocialNetworkException(
                 "Link must be a valid WhatsApp URL (wa.me) or phone number.");
           }
           break;
@@ -122,10 +122,11 @@ public class StoreSocialNetworkService {
       rollbackFor = {
         UnauthorizedException.class,
         ResourceNotFoundException.class,
-        AlreadyExistsException.class
+        AlreadyExistsException.class,
+        InvalidSocialNetworkException.class
       })
   public StoreSocialNetwork addStoreSocialNetwork(UUID storeId, SocialNetworkDTO dto)
-      throws UnauthorizedException, ResourceNotFoundException {
+      throws UnauthorizedException, ResourceNotFoundException, InvalidSocialNetworkException {
 
     Store store = applicationContext.getBean(StoreService.class).findById(storeId);
     authService.assertUserOwnsStore(store);
@@ -150,9 +151,14 @@ public class StoreSocialNetworkService {
     return storeSocialNetworkRepository.save(ssn);
   }
 
-  @Transactional(rollbackFor = {UnauthorizedException.class, ResourceNotFoundException.class})
+  @Transactional(
+      rollbackFor = {
+        UnauthorizedException.class,
+        ResourceNotFoundException.class,
+        InvalidSocialNetworkException.class
+      })
   public StoreSocialNetwork update(UUID id, SocialNetworkUpdateDTO dto)
-      throws UnauthorizedException, ResourceNotFoundException {
+      throws UnauthorizedException, ResourceNotFoundException, InvalidSocialNetworkException {
 
     StoreSocialNetwork relation =
         storeSocialNetworkRepository

--- a/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkService.java
@@ -37,6 +37,7 @@ public class StoreSocialNetworkService {
 
   private void validateByNetwork(String name, String link) {
     String clean = link.replaceAll("\\s+", "");
+    String nameLower = name.toLowerCase();
 
     if (PHONE_NETWORKS.contains(name)) {
       String phoneDigits = clean.startsWith("tel:") ? clean.replace("tel:", "") : clean;
@@ -45,8 +46,46 @@ public class StoreSocialNetworkService {
             "Must be a valid telephone number, formed by 9-15 digits, prefix allowed.");
       }
     } else {
-      if (!link.matches(URL_REGEX)) {
+      boolean isWhatsappPhone = nameLower.equals("whatsapp") && clean.matches(PHONE_REGEX);
+
+      if (!isWhatsappPhone && !link.matches(URL_REGEX)) {
         throw new IllegalArgumentException("Must be a valid URL.");
+      }
+
+      String linkLower = link.toLowerCase();
+
+      switch (nameLower) {
+        case "instagram":
+          if (!linkLower.contains("instagram.com")) {
+            throw new IllegalArgumentException("Link must be a valid Instagram URL.");
+          }
+          break;
+        case "tiktok":
+          if (!linkLower.contains("tiktok.com")) {
+            throw new IllegalArgumentException("Link must be a valid TikTok URL.");
+          }
+          break;
+        case "facebook":
+          if (!linkLower.contains("facebook.com")) {
+            throw new IllegalArgumentException("Link must be a valid Facebook URL.");
+          }
+          break;
+        case "x":
+        case "twitter":
+          if (!linkLower.contains("x.com") && !linkLower.contains("twitter.com")) {
+            throw new IllegalArgumentException("Link must be a valid X/Twitter URL.");
+          }
+          break;
+        case "whatsapp":
+          if (!isWhatsappPhone
+              && !linkLower.contains("wa.me")
+              && !linkLower.contains("whatsapp.com")) {
+            throw new IllegalArgumentException(
+                "Link must be a valid WhatsApp URL (wa.me) or phone number.");
+          }
+          break;
+        default:
+          break;
       }
     }
   }

--- a/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkServiceTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkServiceTest.java
@@ -352,4 +352,53 @@ public class StoreSocialNetworkServiceTest {
     verify(authService, never()).assertUserOwnsStore(store);
     verify(storeSocialNetworkRepository, never()).delete(relation);
   }
+
+  @Test
+  void addStoreSocialNetwork_shouldSaveRelation_whenInstagramUsesIgMe() {
+    when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
+
+    SocialNetworkDTO dto = new SocialNetworkDTO();
+    dto.setName("Instagram");
+    dto.setLink("https://ig.me/m/usuario");
+
+    when(storeService.findById(storeId)).thenReturn(store);
+    when(socialNetworkRepository.findByName("Instagram")).thenReturn(Optional.of(socialNetwork));
+    when(storeSocialNetworkRepository.existsByStoreIdAndSocialNetworkId(storeId, socialNetworkId))
+        .thenReturn(false);
+    when(storeSocialNetworkRepository.save(
+            org.mockito.ArgumentMatchers.any(StoreSocialNetwork.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    StoreSocialNetwork result = storeSocialNetworkService.addStoreSocialNetwork(storeId, dto);
+
+    assertEquals("https://ig.me/m/usuario", result.getLink());
+    verify(storeSocialNetworkRepository).save(any(StoreSocialNetwork.class));
+  }
+
+  @Test
+  void addStoreSocialNetwork_shouldSaveRelation_whenWhatsappUsesTelPrefix() {
+    when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
+
+    SocialNetworkDTO dto = new SocialNetworkDTO();
+    dto.setName("Whatsapp");
+    dto.setLink("tel:+34123456789");
+
+    SocialNetwork whatsappNetwork = new SocialNetwork();
+    whatsappNetwork.setId(UUID.randomUUID());
+    whatsappNetwork.setName("Whatsapp");
+
+    when(storeService.findById(storeId)).thenReturn(store);
+    when(socialNetworkRepository.findByName("Whatsapp")).thenReturn(Optional.of(whatsappNetwork));
+    when(storeSocialNetworkRepository.existsByStoreIdAndSocialNetworkId(
+            storeId, whatsappNetwork.getId()))
+        .thenReturn(false);
+    when(storeSocialNetworkRepository.save(
+            org.mockito.ArgumentMatchers.any(StoreSocialNetwork.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    StoreSocialNetwork result = storeSocialNetworkService.addStoreSocialNetwork(storeId, dto);
+
+    assertEquals("tel:+34123456789", result.getLink());
+    verify(storeSocialNetworkRepository).save(any(StoreSocialNetwork.class));
+  }
 }

--- a/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkServiceTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import ispp.project.dondesiempre.modules.auth.services.AuthService;
 import ispp.project.dondesiempre.modules.common.exceptions.AlreadyExistsException;
+import ispp.project.dondesiempre.modules.common.exceptions.InvalidSocialNetworkException;
 import ispp.project.dondesiempre.modules.common.exceptions.ResourceNotFoundException;
 import ispp.project.dondesiempre.modules.stores.dtos.SocialNetworkDTO;
 import ispp.project.dondesiempre.modules.stores.dtos.SocialNetworkUpdateDTO;
@@ -193,7 +194,7 @@ public class StoreSocialNetworkServiceTest {
         .thenReturn(false);
 
     assertThrows(
-        IllegalArgumentException.class,
+        InvalidSocialNetworkException.class,
         () -> storeSocialNetworkService.addStoreSocialNetwork(storeId, dto));
   }
 
@@ -215,7 +216,7 @@ public class StoreSocialNetworkServiceTest {
         .thenReturn(false);
 
     assertThrows(
-        IllegalArgumentException.class,
+        InvalidSocialNetworkException.class,
         () -> storeSocialNetworkService.addStoreSocialNetwork(storeId, dto));
   }
 
@@ -231,9 +232,9 @@ public class StoreSocialNetworkServiceTest {
     when(storeSocialNetworkRepository.existsByStoreIdAndSocialNetworkId(storeId, socialNetworkId))
         .thenReturn(false);
 
-    IllegalArgumentException exception =
+    InvalidSocialNetworkException exception =
         assertThrows(
-            IllegalArgumentException.class,
+            InvalidSocialNetworkException.class,
             () -> storeSocialNetworkService.addStoreSocialNetwork(storeId, dto));
 
     assertEquals("Link must be a valid Instagram URL.", exception.getMessage());
@@ -256,9 +257,9 @@ public class StoreSocialNetworkServiceTest {
             storeId, whatsappNetwork.getId()))
         .thenReturn(false);
 
-    IllegalArgumentException exception =
+    InvalidSocialNetworkException exception =
         assertThrows(
-            IllegalArgumentException.class,
+            InvalidSocialNetworkException.class,
             () -> storeSocialNetworkService.addStoreSocialNetwork(storeId, dto));
 
     assertEquals(
@@ -307,7 +308,8 @@ public class StoreSocialNetworkServiceTest {
         .thenReturn(Optional.of(relation));
 
     assertThrows(
-        IllegalArgumentException.class, () -> storeSocialNetworkService.update(relationId, dto));
+        InvalidSocialNetworkException.class,
+        () -> storeSocialNetworkService.update(relationId, dto));
   }
 
   @Test
@@ -318,9 +320,9 @@ public class StoreSocialNetworkServiceTest {
     when(storeSocialNetworkRepository.findByIdWithSocialNetwork(relationId))
         .thenReturn(Optional.of(relation));
 
-    IllegalArgumentException exception =
+    InvalidSocialNetworkException exception =
         assertThrows(
-            IllegalArgumentException.class,
+            InvalidSocialNetworkException.class,
             () -> storeSocialNetworkService.update(relationId, dto));
 
     assertEquals("Link must be a valid Instagram URL.", exception.getMessage());

--- a/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkServiceTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreSocialNetworkServiceTest.java
@@ -220,6 +220,52 @@ public class StoreSocialNetworkServiceTest {
   }
 
   @Test
+  void addStoreSocialNetwork_shouldThrowException_whenMismatchedDomain() {
+    SocialNetworkDTO dto = new SocialNetworkDTO();
+    dto.setName("Instagram");
+    dto.setLink("https://tiktok.com/@midominio");
+
+    when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
+    when(storeService.findById(storeId)).thenReturn(store);
+    when(socialNetworkRepository.findByName("Instagram")).thenReturn(Optional.of(socialNetwork));
+    when(storeSocialNetworkRepository.existsByStoreIdAndSocialNetworkId(storeId, socialNetworkId))
+        .thenReturn(false);
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> storeSocialNetworkService.addStoreSocialNetwork(storeId, dto));
+
+    assertEquals("Link must be a valid Instagram URL.", exception.getMessage());
+  }
+
+  @Test
+  void addStoreSocialNetwork_shouldThrowException_whenWhatsappHasInvalidLink() {
+    SocialNetworkDTO dto = new SocialNetworkDTO();
+    dto.setName("Whatsapp");
+    dto.setLink("https://google.com");
+
+    SocialNetwork whatsappNetwork = new SocialNetwork();
+    whatsappNetwork.setId(UUID.randomUUID());
+    whatsappNetwork.setName("Whatsapp");
+
+    when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
+    when(storeService.findById(storeId)).thenReturn(store);
+    when(socialNetworkRepository.findByName("Whatsapp")).thenReturn(Optional.of(whatsappNetwork));
+    when(storeSocialNetworkRepository.existsByStoreIdAndSocialNetworkId(
+            storeId, whatsappNetwork.getId()))
+        .thenReturn(false);
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> storeSocialNetworkService.addStoreSocialNetwork(storeId, dto));
+
+    assertEquals(
+        "Link must be a valid WhatsApp URL (wa.me) or phone number.", exception.getMessage());
+  }
+
+  @Test
   void update_shouldModifyLink_whenRelationExists() {
     SocialNetworkUpdateDTO dto = new SocialNetworkUpdateDTO();
     dto.setLink("https://instagram.com/new-link");
@@ -262,6 +308,22 @@ public class StoreSocialNetworkServiceTest {
 
     assertThrows(
         IllegalArgumentException.class, () -> storeSocialNetworkService.update(relationId, dto));
+  }
+
+  @Test
+  void update_shouldThrowException_whenMismatchedDomain() {
+    SocialNetworkUpdateDTO dto = new SocialNetworkUpdateDTO();
+    dto.setLink("https://facebook.com/mi-pagina");
+
+    when(storeSocialNetworkRepository.findByIdWithSocialNetwork(relationId))
+        .thenReturn(Optional.of(relation));
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> storeSocialNetworkService.update(relationId, dto));
+
+    assertEquals("Link must be a valid Instagram URL.", exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
# Backend Pull Request

## Description

Se ha implementado una validación estricta de dominio y formato para los enlaces de las redes sociales de las tiendas. El objetivo es evitar que los usuarios introduzcan enlaces incorrectos o cruzados (por ejemplo, poner un enlace de TikTok en el perfil de Instagram).

- Se ha actualizado la lógica en StoreSocialNetworkService para verificar que la URL contenga el dominio correspondiente a la red social seleccionada (instagram.com, tiktok.com, facebook.com, x.com, etc.).
- Se ha mejorado la gestión de WhatsApp, validando que el input sea un enlace válido (wa.me / whatsapp.com) o un número de teléfono con formato correcto.
- Se han añadido nuevos casos de prueba en StoreSocialNetworkServiceTest para garantizar que todas las validaciones de dominio y formato lanzan las excepciones IllegalArgumentException esperadas cuando los datos son inválidos.

---

## Type of Change

- [ ] New endpoint
- [X] Bug fix
- [X] Refactor
- [ ] Performance improvement

---

## Database Changes (if applicable)

- [ ] Migration added
- [ ] Schema updated
- [ ] Seed updated

---

## Checklist

- [X] I made sure tests are passing locally
- [X] I handled error cases
- [X] I followed the style guides
- [X] I followed the Controller-Service-Repository pattern
- [X] I tested my code