### PR TITLE
Fix/product outfit price inconsistency

### DIFF
--- a/src/main/java/ispp/project/dondesiempre/modules/orders/controllers/OrderController.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/orders/controllers/OrderController.java
@@ -8,6 +8,7 @@ import ispp.project.dondesiempre.modules.products.models.Product;
 import ispp.project.dondesiempre.modules.products.services.ProductService;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -45,8 +46,8 @@ public class OrderController {
 
   @PostMapping
   public ResponseEntity<OrderDTO> createOrder(
-      @RequestBody Map<UUID, Integer> productIdsWithQuantity,
-      @RequestParam(required = false) UUID outfitId) {
+      @RequestBody Map<UUID, Integer> productIdsWithQuantity, @RequestParam Optional<UUID> outfitId)
+      throws ResourceNotFoundException {
 
     Map<Product, Integer> productsToBuy =
         productIdsWithQuantity.entrySet().stream()
@@ -54,7 +55,7 @@ public class OrderController {
                 Collectors.toMap(
                     e -> productService.getProductById(e.getKey()), Map.Entry::getValue));
 
-    OrderDTO response = orderService.createOrder(productsToBuy, outfitId);
+    OrderDTO response = orderService.createOrder(productsToBuy, outfitId.orElse(null));
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 

--- a/src/main/java/ispp/project/dondesiempre/modules/orders/controllers/OrderController.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/orders/controllers/OrderController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -44,7 +45,8 @@ public class OrderController {
 
   @PostMapping
   public ResponseEntity<OrderDTO> createOrder(
-      @RequestBody Map<UUID, Integer> productIdsWithQuantity) {
+      @RequestBody Map<UUID, Integer> productIdsWithQuantity,
+      @RequestParam(required = false) UUID outfitId) {
 
     Map<Product, Integer> productsToBuy =
         productIdsWithQuantity.entrySet().stream()
@@ -52,7 +54,7 @@ public class OrderController {
                 Collectors.toMap(
                     e -> productService.getProductById(e.getKey()), Map.Entry::getValue));
 
-    OrderDTO response = orderService.createOrder(productsToBuy);
+    OrderDTO response = orderService.createOrder(productsToBuy, outfitId);
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 

--- a/src/main/java/ispp/project/dondesiempre/modules/orders/services/OrderService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/orders/services/OrderService.java
@@ -10,6 +10,8 @@ import ispp.project.dondesiempre.modules.orders.models.Order;
 import ispp.project.dondesiempre.modules.orders.models.OrderItem;
 import ispp.project.dondesiempre.modules.orders.models.OrderStatus;
 import ispp.project.dondesiempre.modules.orders.repositories.OrderRepository;
+import ispp.project.dondesiempre.modules.outfits.models.Outfit;
+import ispp.project.dondesiempre.modules.outfits.repositories.OutfitRepository;
 import ispp.project.dondesiempre.modules.products.models.Product;
 import ispp.project.dondesiempre.modules.stores.models.Store;
 import ispp.project.dondesiempre.modules.stores.repositories.StoreRepository;
@@ -35,6 +37,7 @@ public class OrderService {
   private final AuthService authService;
   private final CryptoConverter cryptoConverter;
   private final ApplicationContext applicationContext;
+  private final OutfitRepository outfitRepository;
 
   private final SecureRandom secureRandom = new SecureRandom();
   private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -139,7 +142,7 @@ public class OrderService {
   }
 
   @Transactional(rollbackFor = ResourceNotFoundException.class)
-  public OrderDTO createOrder(Map<Product, Integer> productsToBuy) {
+  public OrderDTO createOrder(Map<Product, Integer> productsToBuy, UUID outfitId) {
     User user = authService.getCurrentUser();
 
     Order order = new Order();
@@ -158,7 +161,17 @@ public class OrderService {
       order.getItems().add(item);
     }
 
-    order.setTotalPrice(this.calculateAndSetTotalPrice(order));
+    Integer total = this.calculateAndSetTotalPrice(order);
+
+    if (outfitId != null) {
+      Outfit outfit = outfitRepository.findById(outfitId).orElse(null);
+      if (outfit != null && outfit.getDiscountPercentage().isPresent()) {
+        Integer discount = outfit.getDiscountPercentage().get();
+        total = (total * (100 - discount)) / 100;
+      }
+    }
+
+    order.setTotalPrice(total);
     Order savedOrder = orderRepository.save(order);
 
     return mapToOrderDTO(savedOrder);
@@ -224,15 +237,6 @@ public class OrderService {
     }
   }
 
-  // Este método se puede usar para cancelar un pedido que aún no ha sido
-  // confirmado.
-  /**
-   * TODO: Podría añadirse que un pedido sea cancelado por un cliente o una tienda, si y solo si: -
-   * Cliente: puede cancelar un pedido si está PENDING (se ha equivocado, se ha dado cuenta que no
-   * quería X item, etc.) - Tienda: puede cancelar un pedido si está CONFIRMED (se han dado cuenta
-   * que no queda stock, el pedido es imposible de preparar, etc.) Ahora mismo no está teniendo en
-   * cuenta estos roles.
-   */
   @Transactional
   public void cancelOrder(UUID orderId) throws UnauthorizedException, ResourceNotFoundException {
     Order order =

--- a/src/main/java/ispp/project/dondesiempre/modules/orders/services/OrderService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/orders/services/OrderService.java
@@ -11,7 +11,7 @@ import ispp.project.dondesiempre.modules.orders.models.OrderItem;
 import ispp.project.dondesiempre.modules.orders.models.OrderStatus;
 import ispp.project.dondesiempre.modules.orders.repositories.OrderRepository;
 import ispp.project.dondesiempre.modules.outfits.models.Outfit;
-import ispp.project.dondesiempre.modules.outfits.repositories.OutfitRepository;
+import ispp.project.dondesiempre.modules.outfits.services.OutfitService;
 import ispp.project.dondesiempre.modules.products.models.Product;
 import ispp.project.dondesiempre.modules.stores.models.Store;
 import ispp.project.dondesiempre.modules.stores.repositories.StoreRepository;
@@ -37,7 +37,7 @@ public class OrderService {
   private final AuthService authService;
   private final CryptoConverter cryptoConverter;
   private final ApplicationContext applicationContext;
-  private final OutfitRepository outfitRepository;
+  private final OutfitService outfitService;
 
   private final SecureRandom secureRandom = new SecureRandom();
   private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -142,7 +142,8 @@ public class OrderService {
   }
 
   @Transactional(rollbackFor = ResourceNotFoundException.class)
-  public OrderDTO createOrder(Map<Product, Integer> productsToBuy, UUID outfitId) {
+  public OrderDTO createOrder(Map<Product, Integer> productsToBuy, UUID outfitId)
+      throws ResourceNotFoundException {
     User user = authService.getCurrentUser();
 
     Order order = new Order();
@@ -164,7 +165,7 @@ public class OrderService {
     Integer total = this.calculateAndSetTotalPrice(order);
 
     if (outfitId != null) {
-      Outfit outfit = outfitRepository.findById(outfitId).orElse(null);
+      Outfit outfit = outfitService.findById(outfitId);
       if (outfit != null && outfit.getDiscountPercentage().isPresent()) {
         Integer discount = outfit.getDiscountPercentage().get();
         total = (total * (100 - discount)) / 100;

--- a/src/test/java/ispp/project/dondesiempre/modules/order/controllers/OrderControllerTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/order/controllers/OrderControllerTest.java
@@ -1,6 +1,7 @@
 package ispp.project.dondesiempre.modules.order.controllers;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -110,7 +111,7 @@ class OrderControllerTest {
     Map<UUID, Integer> payload = Map.of(productId, 1);
 
     when(productService.getProductById(productId)).thenReturn(product);
-    when(orderService.createOrder(any(Map.class))).thenReturn(orderDTO);
+    when(orderService.createOrder(any(Map.class), any())).thenReturn(orderDTO);
 
     mockMvc
         .perform(
@@ -121,7 +122,29 @@ class OrderControllerTest {
         .andExpect(jsonPath("$.id").value(orderId.toString()));
 
     verify(productService, times(1)).getProductById(productId);
-    verify(orderService, times(1)).createOrder(any(Map.class));
+    verify(orderService, times(1)).createOrder(any(Map.class), any());
+  }
+
+  @Test
+  @WithMockUser
+  void createOrder_withOutfit_shouldReturnCreated() throws Exception {
+    UUID outfitId = UUID.randomUUID();
+    Map<UUID, Integer> payload = Map.of(productId, 1);
+
+    when(productService.getProductById(productId)).thenReturn(product);
+    when(orderService.createOrder(any(Map.class), eq(outfitId))).thenReturn(orderDTO);
+
+    mockMvc
+        .perform(
+            post("/api/v1/orders")
+                .param("outfitId", outfitId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(orderId.toString()));
+
+    verify(productService, times(1)).getProductById(productId);
+    verify(orderService, times(1)).createOrder(any(Map.class), eq(outfitId));
   }
 
   @Test

--- a/src/test/java/ispp/project/dondesiempre/modules/order/services/OrderServiceTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/order/services/OrderServiceTest.java
@@ -22,7 +22,7 @@ import ispp.project.dondesiempre.modules.orders.models.OrderStatus;
 import ispp.project.dondesiempre.modules.orders.repositories.OrderRepository;
 import ispp.project.dondesiempre.modules.orders.services.OrderService;
 import ispp.project.dondesiempre.modules.outfits.models.Outfit;
-import ispp.project.dondesiempre.modules.outfits.repositories.OutfitRepository;
+import ispp.project.dondesiempre.modules.outfits.services.OutfitService;
 import ispp.project.dondesiempre.modules.products.models.Product;
 import ispp.project.dondesiempre.modules.stores.models.Store;
 import ispp.project.dondesiempre.modules.stores.repositories.StoreRepository;
@@ -51,7 +51,7 @@ public class OrderServiceTest {
   @Mock private AuthService authService;
   @Mock private CryptoConverter cryptoConverter;
   @Mock private ApplicationContext applicationContext;
-  @Mock private OutfitRepository outfitRepository;
+  @Mock private OutfitService outfitService;
 
   @InjectMocks private OrderService orderService;
 
@@ -159,7 +159,7 @@ public class OrderServiceTest {
   }
 
   @Test
-  void createOrder_ShouldCreateAndReturnDTO() {
+  void createOrder_ShouldCreateAndReturnDTO() throws Exception {
     when(authService.getCurrentUser()).thenReturn(user);
     when(orderRepository.save(any())).thenReturn(order);
     Map<Product, Integer> products = Map.of(product, 2);
@@ -171,14 +171,14 @@ public class OrderServiceTest {
   }
 
   @Test
-  void createOrder_WithOutfitDiscount_ShouldApplyDiscount() {
+  void createOrder_WithOutfitDiscount_ShouldApplyDiscount() throws Exception {
     UUID outfitId = UUID.randomUUID();
     Outfit outfit = new Outfit();
     outfit.setId(outfitId);
     outfit.setDiscountPercentage(20);
 
     when(authService.getCurrentUser()).thenReturn(user);
-    when(outfitRepository.findById(outfitId)).thenReturn(Optional.of(outfit));
+    when(outfitService.findById(outfitId)).thenReturn(outfit);
     when(orderRepository.save(any(Order.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -192,14 +192,14 @@ public class OrderServiceTest {
   }
 
   @Test
-  void createOrder_WithOutfitDiscount_ShouldTruncateCorrectly() {
+  void createOrder_WithOutfitDiscount_ShouldTruncateCorrectly() throws Exception {
     UUID outfitId = UUID.randomUUID();
     Outfit outfit = new Outfit();
     outfit.setId(outfitId);
     outfit.setDiscountPercentage(25);
 
     when(authService.getCurrentUser()).thenReturn(user);
-    when(outfitRepository.findById(outfitId)).thenReturn(Optional.of(outfit));
+    when(outfitService.findById(outfitId)).thenReturn(outfit);
     when(orderRepository.save(any(Order.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
 

--- a/src/test/java/ispp/project/dondesiempre/modules/order/services/OrderServiceTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/order/services/OrderServiceTest.java
@@ -21,6 +21,8 @@ import ispp.project.dondesiempre.modules.orders.models.OrderItem;
 import ispp.project.dondesiempre.modules.orders.models.OrderStatus;
 import ispp.project.dondesiempre.modules.orders.repositories.OrderRepository;
 import ispp.project.dondesiempre.modules.orders.services.OrderService;
+import ispp.project.dondesiempre.modules.outfits.models.Outfit;
+import ispp.project.dondesiempre.modules.outfits.repositories.OutfitRepository;
 import ispp.project.dondesiempre.modules.products.models.Product;
 import ispp.project.dondesiempre.modules.stores.models.Store;
 import ispp.project.dondesiempre.modules.stores.repositories.StoreRepository;
@@ -37,6 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,6 +50,8 @@ public class OrderServiceTest {
   @Mock private StoreRepository storeRepository;
   @Mock private AuthService authService;
   @Mock private CryptoConverter cryptoConverter;
+  @Mock private ApplicationContext applicationContext;
+  @Mock private OutfitRepository outfitRepository;
 
   @InjectMocks private OrderService orderService;
 
@@ -159,10 +164,56 @@ public class OrderServiceTest {
     when(orderRepository.save(any())).thenReturn(order);
     Map<Product, Integer> products = Map.of(product, 2);
 
-    OrderDTO result = orderService.createOrder(products);
+    OrderDTO result = orderService.createOrder(products, null);
 
     assertNotNull(result);
     verify(orderRepository).save(any(Order.class));
+  }
+
+  @Test
+  void createOrder_WithOutfitDiscount_ShouldApplyDiscount() {
+    UUID outfitId = UUID.randomUUID();
+    Outfit outfit = new Outfit();
+    outfit.setId(outfitId);
+    outfit.setDiscountPercentage(20);
+
+    when(authService.getCurrentUser()).thenReturn(user);
+    when(outfitRepository.findById(outfitId)).thenReturn(Optional.of(outfit));
+    when(orderRepository.save(any(Order.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    Map<Product, Integer> products = Map.of(product, 2);
+
+    OrderDTO result = orderService.createOrder(products, outfitId);
+
+    assertNotNull(result);
+    assertEquals(160, result.getTotalPrice());
+    verify(orderRepository).save(any(Order.class));
+  }
+
+  @Test
+  void createOrder_WithOutfitDiscount_ShouldTruncateCorrectly() {
+    UUID outfitId = UUID.randomUUID();
+    Outfit outfit = new Outfit();
+    outfit.setId(outfitId);
+    outfit.setDiscountPercentage(25);
+
+    when(authService.getCurrentUser()).thenReturn(user);
+    when(outfitRepository.findById(outfitId)).thenReturn(Optional.of(outfit));
+    when(orderRepository.save(any(Order.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    Product productTruncateTest = new Product();
+    productTruncateTest.setStore(store);
+    productTruncateTest.setPriceInCents(3998);
+    productTruncateTest.setName("Producto Truncado");
+
+    Map<Product, Integer> products = Map.of(productTruncateTest, 1);
+
+    OrderDTO result = orderService.createOrder(products, outfitId);
+
+    assertNotNull(result);
+    assertEquals(2998, result.getTotalPrice());
   }
 
   @Test


### PR DESCRIPTION
# Backend Pull Request

## Description

Se ha corregido un fallo por el cual el precio final de un pedido creado a partir de un outfit no tenía en cuenta el porcentaje de descuento del propio outfit, cobrando la suma íntegra de los precios individuales de cada producto.

- Se ha modificado el endpoint POST /api/v1/orders en OrderController para aceptar un parámetro opcional en la query (outfitId).
- En OrderService, se ha inyectado el OutfitRepository para poder recuperar el outfit si se proporciona su ID, y así aplicar su porcentaje de descuento al precio base del pedido.
- Se ha solucionado una discrepancia de cálculo de decimales utilizando exclusivamente aritmética de enteros (total * (100 - discount)) / 100. Esto asegura que el truncamiento en el backend coincida de forma exacta con los cálculos del frontend.
- Se han actualizado y añadido nuevos tests unitarios en OrderControllerTest y OrderServiceTest para verificar que el descuento se aplica correctamente y que el truncamiento de céntimos funciona como se espera.

---

## Type of Change

- [ ] New endpoint
- [X] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Database Changes (if applicable)

- [ ] Migration added
- [ ] Schema updated
- [ ] Seed updated

---

## Checklist

- [X] I made sure tests are passing locally
- [X] I handled error cases
- [X] I followed the style guides
- [X] I followed the Controller-Service-Repository pattern
- [X] I tested my code
