### PR TITLE
feat: modifications done to show newest orders first

### DIFF
--- a/src/main/java/ispp/project/dondesiempre/modules/orders/services/OrderService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/orders/services/OrderService.java
@@ -18,6 +18,7 @@ import ispp.project.dondesiempre.modules.stores.repositories.StoreRepository;
 import ispp.project.dondesiempre.utils.crypto.CryptoConverter;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -63,12 +64,18 @@ public class OrderService {
       orders = orderRepository.findByUserId(currentUser.getId());
     }
 
-    return orders.stream().map(this::mapToOrderDTO).toList();
+    return orders.stream()
+        .sorted(Comparator.comparing(Order::getOrderDate).reversed())
+        .map(this::mapToOrderDTO)
+        .toList();
   }
 
   @Transactional(readOnly = true)
   public List<OrderDTO> findOrdersByUserId(UUID userId) {
-    return orderRepository.findByUserId(userId).stream().map(this::mapToOrderDTO).toList();
+    return orderRepository.findByUserId(userId).stream()
+        .sorted(Comparator.comparing(Order::getOrderDate).reversed())
+        .map(this::mapToOrderDTO)
+        .toList();
   }
 
   @Transactional(readOnly = true, rollbackFor = ResourceNotFoundException.class)

--- a/src/test/java/ispp/project/dondesiempre/modules/order/services/OrderServiceTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/order/services/OrderServiceTest.java
@@ -102,34 +102,68 @@ public class OrderServiceTest {
   }
 
   @Test
-  void findOrdersOfCurrentUser_AsClient_ShouldReturnDTOs() {
+  void findOrdersOfCurrentUser_AsClient_ShouldReturnSortedDTOs() {
+    Order olderOrder = new Order();
+    olderOrder.setId(UUID.randomUUID());
+    olderOrder.setUser(user);
+    olderOrder.setOrderStatus(OrderStatus.PENDING);
+    olderOrder.setOrderDate(LocalDateTime.now().minusDays(5)); // Más antiguo
+    olderOrder.setItems(new ArrayList<>(List.of(item)));
+    olderOrder.setOrderCode("CODE-OLD");
+    olderOrder.setTotalPrice(100);
+
     when(authService.getCurrentUser()).thenReturn(user);
     when(storeRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
-    when(orderRepository.findByUserId(user.getId())).thenReturn(List.of(order));
+    // Simulamos que la base de datos los devuelve desordenados (antiguo primero)
+    when(orderRepository.findByUserId(user.getId())).thenReturn(List.of(olderOrder, order));
 
     List<OrderDTO> result = orderService.findOrdersOfCurrenUser();
 
     assertFalse(result.isEmpty());
+    assertEquals(2, result.size());
+    // Verificamos que el más nuevo esté primero
+    assertEquals(order.getId(), result.get(0).getId());
+    assertEquals(olderOrder.getId(), result.get(1).getId());
     assertEquals("Tienda Test", result.get(0).getStoreName());
   }
 
   @Test
-  void findOrdersOfCurrentUser_AsStore_ShouldReturnStoreOrders() {
+  void findOrdersOfCurrentUser_AsStore_ShouldReturnSortedStoreOrders() {
+    Order olderOrder = new Order();
+    olderOrder.setId(UUID.randomUUID());
+    olderOrder.setUser(user);
+    olderOrder.setOrderDate(LocalDateTime.now().minusDays(2));
+    olderOrder.setItems(new ArrayList<>(List.of(item)));
+
     when(authService.getCurrentUser()).thenReturn(user);
     when(storeRepository.findByUserId(user.getId())).thenReturn(Optional.of(store));
-    when(orderRepository.findByStoreId(store.getId())).thenReturn(List.of(order));
+    when(orderRepository.findByStoreId(store.getId())).thenReturn(List.of(olderOrder, order));
 
     List<OrderDTO> result = orderService.findOrdersOfCurrenUser();
 
     assertFalse(result.isEmpty());
+    assertEquals(2, result.size());
+    // Verificamos el orden descendente
+    assertEquals(order.getId(), result.get(0).getId());
+    assertEquals(olderOrder.getId(), result.get(1).getId());
     verify(orderRepository).findByStoreId(store.getId());
   }
 
   @Test
-  void findOrdersByUserId_ShouldReturnList() {
-    when(orderRepository.findByUserId(user.getId())).thenReturn(List.of(order));
+  void findOrdersByUserId_ShouldReturnSortedList() {
+    Order olderOrder = new Order();
+    olderOrder.setId(UUID.randomUUID());
+    olderOrder.setUser(user);
+    olderOrder.setOrderDate(LocalDateTime.now().minusDays(10));
+    olderOrder.setItems(new ArrayList<>(List.of(item)));
+
+    when(orderRepository.findByUserId(user.getId())).thenReturn(List.of(olderOrder, order));
+
     List<OrderDTO> result = orderService.findOrdersByUserId(user.getId());
-    assertEquals(1, result.size());
+
+    assertEquals(2, result.size());
+    assertEquals(order.getId(), result.get(0).getId());
+    assertEquals(olderOrder.getId(), result.get(1).getId());
   }
 
   @Test


### PR DESCRIPTION
# Backend Pull Request

## Description

Se ha corregido y ajustado la ordenación de los pedidos para que se muestren los más recientes primero (orden descendente por fecha de creación). 

**Cambios principales:**
* Se ha añadido `.sorted(Comparator.comparing(Order::getOrderDate).reversed())` en `OrderService` (Backend) para devolver las listas de pedidos ordenadas correctamente desde el servidor.
* Se han modificado los tests en `OrderServiceTest` introduciendo un `olderOrder` para verificar de forma estricta que la lógica de ordenación descendente funciona y evitar posibles regresiones en el futuro.

---

## Type of Change

- [ ] New endpoint
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Database Changes (if applicable)

- [ ] Migration added
- [ ] Schema updated
- [ ] Seed updated

*(No aplica para este PR)*

---

## Checklist

- [x] I made sure tests are passing locally
- [x] I handled error cases
- [x] I followed the style guides
- [x] I followed the Controller-Service-Repository pattern
- [x] I tested my code


> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github