### PR TITLE
Fix/about us image use image upload

### DIFF
--- a/src/main/java/ispp/project/dondesiempre/config/GlobalExceptionHandler.java
+++ b/src/main/java/ispp/project/dondesiempre/config/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -64,6 +65,13 @@ public class GlobalExceptionHandler {
   public ResponseEntity<String> handleStripeException(
       AlreadyExistsException exception, WebRequest request) {
     return new ResponseEntity<>(exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<String> handleMaxSizeException(
+      MaxUploadSizeExceededException exception, WebRequest request) {
+    return new ResponseEntity<>(exception.getMessage(), HttpStatus.PAYLOAD_TOO_LARGE);
   }
 
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/ispp/project/dondesiempre/modules/stores/controllers/StoreImageController.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/stores/controllers/StoreImageController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,8 +18,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -36,13 +39,15 @@ public class StoreImageController {
     return new ResponseEntity<>(images, HttpStatus.OK);
   }
 
-  @PostMapping("stores/{storeId}/images")
+  @PostMapping(value = "stores/{storeId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<StoreImageDTO> create(
-      @PathVariable UUID storeId, @RequestBody @Valid StoreImageUpdateDTO dto) {
+      @PathVariable UUID storeId,
+      @RequestPart("dto") @Valid StoreImageUpdateDTO dto,
+      @RequestPart("image") MultipartFile image) {
 
-    StoreImageDTO image = storeImageService.add(storeId, dto);
+    StoreImageDTO createdImage = storeImageService.add(storeId, dto, image);
 
-    return new ResponseEntity<>(image, HttpStatus.CREATED);
+    return new ResponseEntity<>(createdImage, HttpStatus.CREATED);
   }
 
   @PutMapping("stores/{storeId}/images/{id}")

--- a/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
@@ -72,6 +72,20 @@ public class StoreImageService {
       throw new InvalidRequestException("Image file is required.");
     }
 
+    if (dto.getDisplayOrder() < 0 || dto.getDisplayOrder() > existingImages.size()) {
+      throw new InvalidRequestException("El índice proporcionado no es válido.");
+    }
+
+    if (dto.getDisplayOrder() < existingImages.size()) {
+      existingImages.stream()
+          .filter(img -> img.getDisplayOrder() >= dto.getDisplayOrder())
+          .forEach(
+              img -> {
+                img.setDisplayOrder(img.getDisplayOrder() + 1);
+                storeImageRepository.save(img);
+              });
+    }
+
     StoreImage image = new StoreImage();
     image.setImage(cloudinaryService.upload(imageFile));
     image.setDisplayOrder(dto.getDisplayOrder());
@@ -80,15 +94,47 @@ public class StoreImageService {
     return toDTO(storeImageRepository.save(image));
   }
 
-  @Transactional(rollbackFor = {UnauthorizedException.class, ResourceNotFoundException.class})
+  @Transactional(
+      rollbackFor = {
+        UnauthorizedException.class,
+        ResourceNotFoundException.class,
+        InvalidRequestException.class
+      })
   public StoreImageDTO update(UUID imageId, StoreImageUpdateDTO dto)
-      throws UnauthorizedException, ResourceNotFoundException {
+      throws UnauthorizedException, ResourceNotFoundException, InvalidRequestException {
 
     StoreImage imageToUpdate = findImageById(imageId);
     authService.assertUserOwnsStore(imageToUpdate.getStore());
 
+    List<StoreImage> existingImages =
+        storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(
+            imageToUpdate.getStore().getId());
+
+    int maxIndex = existingImages.size() - 1;
+
+    if (dto.getDisplayOrder() < 0 || dto.getDisplayOrder() > maxIndex) {
+      throw new InvalidRequestException(
+          "El índice proporcionado no es válido. Debe estar entre 0 y " + maxIndex);
+    }
+
+    Integer oldOrder = imageToUpdate.getDisplayOrder();
+    Integer newOrder = dto.getDisplayOrder();
+
+    if (!oldOrder.equals(newOrder)) {
+      StoreImage imageToSwap =
+          existingImages.stream()
+              .filter(img -> img.getDisplayOrder().equals(newOrder))
+              .findFirst()
+              .orElse(null);
+
+      if (imageToSwap != null) {
+        imageToSwap.setDisplayOrder(oldOrder);
+        storeImageRepository.save(imageToSwap);
+      }
+    }
+
     imageToUpdate.setImage(dto.getImage());
-    imageToUpdate.setDisplayOrder(dto.getDisplayOrder());
+    imageToUpdate.setDisplayOrder(newOrder);
 
     return toDTO(storeImageRepository.save(imageToUpdate));
   }

--- a/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
@@ -72,23 +72,9 @@ public class StoreImageService {
       throw new InvalidRequestException("Image file is required.");
     }
 
-    if (dto.getDisplayOrder() < 0 || dto.getDisplayOrder() > existingImages.size()) {
-      throw new InvalidRequestException("El índice proporcionado no es válido.");
-    }
-
-    if (dto.getDisplayOrder() < existingImages.size()) {
-      existingImages.stream()
-          .filter(img -> img.getDisplayOrder() >= dto.getDisplayOrder())
-          .forEach(
-              img -> {
-                img.setDisplayOrder(img.getDisplayOrder() + 1);
-                storeImageRepository.save(img);
-              });
-    }
-
     StoreImage image = new StoreImage();
     image.setImage(cloudinaryService.upload(imageFile));
-    image.setDisplayOrder(dto.getDisplayOrder());
+    image.setDisplayOrder(existingImages.size());
     image.setStore(storeToUpdate);
 
     return toDTO(storeImageRepository.save(image));
@@ -106,35 +92,8 @@ public class StoreImageService {
     StoreImage imageToUpdate = findImageById(imageId);
     authService.assertUserOwnsStore(imageToUpdate.getStore());
 
-    List<StoreImage> existingImages =
-        storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(
-            imageToUpdate.getStore().getId());
-
-    int maxIndex = existingImages.size() - 1;
-
-    if (dto.getDisplayOrder() < 0 || dto.getDisplayOrder() > maxIndex) {
-      throw new InvalidRequestException(
-          "El índice proporcionado no es válido. Debe estar entre 0 y " + maxIndex);
-    }
-
-    Integer oldOrder = imageToUpdate.getDisplayOrder();
-    Integer newOrder = dto.getDisplayOrder();
-
-    if (!oldOrder.equals(newOrder)) {
-      StoreImage imageToSwap =
-          existingImages.stream()
-              .filter(img -> img.getDisplayOrder().equals(newOrder))
-              .findFirst()
-              .orElse(null);
-
-      if (imageToSwap != null) {
-        imageToSwap.setDisplayOrder(oldOrder);
-        storeImageRepository.save(imageToSwap);
-      }
-    }
-
     imageToUpdate.setImage(dto.getImage());
-    imageToUpdate.setDisplayOrder(newOrder);
+    imageToUpdate.setDisplayOrder(dto.getDisplayOrder());
 
     return toDTO(storeImageRepository.save(imageToUpdate));
   }

--- a/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
@@ -10,12 +10,14 @@ import ispp.project.dondesiempre.modules.stores.models.Store;
 import ispp.project.dondesiempre.modules.stores.models.StoreImage;
 import ispp.project.dondesiempre.modules.stores.repositories.StoreImageRepository;
 import ispp.project.dondesiempre.modules.stores.repositories.StoreRepository;
+import ispp.project.dondesiempre.utils.cloudinary.CloudinaryService;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class StoreImageService {
   private final StoreImageRepository storeImageRepository;
   private final ApplicationContext applicationContext;
   private final AuthService authService;
+  private final CloudinaryService cloudinaryService;
 
   public Store findById(UUID id) throws ResourceNotFoundException {
     return storeRepository
@@ -51,7 +54,7 @@ public class StoreImageService {
         ResourceNotFoundException.class,
         InvalidRequestException.class
       })
-  public StoreImageDTO add(UUID id, StoreImageUpdateDTO dto)
+  public StoreImageDTO add(UUID id, StoreImageUpdateDTO dto, MultipartFile imageFile)
       throws UnauthorizedException, ResourceNotFoundException, InvalidRequestException {
 
     Store storeToUpdate = applicationContext.getBean(StoreService.class).findById(id);
@@ -64,8 +67,12 @@ public class StoreImageService {
       throw new InvalidRequestException("A store cannot have more than 5 images.");
     }
 
+    if (imageFile == null || imageFile.isEmpty()) {
+      throw new InvalidRequestException("Image file is required.");
+    }
+
     StoreImage image = new StoreImage();
-    image.setImage(dto.getImage());
+    image.setImage(cloudinaryService.upload(imageFile));
     image.setDisplayOrder(dto.getDisplayOrder());
     image.setStore(storeToUpdate);
 

--- a/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
@@ -13,6 +13,8 @@ import ispp.project.dondesiempre.modules.stores.repositories.StoreRepository;
 import ispp.project.dondesiempre.utils.cloudinary.CloudinaryService;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
@@ -48,20 +50,18 @@ public class StoreImageService {
     return new StoreImageDTO(storeImage);
   }
 
-  @Transactional(
-      rollbackFor = {
-        UnauthorizedException.class,
-        ResourceNotFoundException.class,
-        InvalidRequestException.class
-      })
+  @Transactional(rollbackFor = {
+      UnauthorizedException.class,
+      ResourceNotFoundException.class,
+      InvalidRequestException.class
+  })
   public StoreImageDTO add(UUID id, StoreImageUpdateDTO dto, MultipartFile imageFile)
       throws UnauthorizedException, ResourceNotFoundException, InvalidRequestException {
 
     Store storeToUpdate = applicationContext.getBean(StoreService.class).findById(id);
     authService.assertUserOwnsStore(storeToUpdate);
 
-    List<StoreImage> existingImages =
-        storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(id);
+    List<StoreImage> existingImages = storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(id);
 
     if (existingImages.size() >= 5) {
       throw new InvalidRequestException("A store cannot have more than 5 images.");
@@ -79,7 +79,7 @@ public class StoreImageService {
     return toDTO(storeImageRepository.save(image));
   }
 
-  @Transactional(rollbackFor = {UnauthorizedException.class, ResourceNotFoundException.class})
+  @Transactional(rollbackFor = { UnauthorizedException.class, ResourceNotFoundException.class })
   public StoreImageDTO update(UUID imageId, StoreImageUpdateDTO dto)
       throws UnauthorizedException, ResourceNotFoundException {
 
@@ -92,10 +92,20 @@ public class StoreImageService {
     return toDTO(storeImageRepository.save(imageToUpdate));
   }
 
-  @Transactional(rollbackFor = {UnauthorizedException.class, ResourceNotFoundException.class})
+  @Transactional(rollbackFor = { UnauthorizedException.class, ResourceNotFoundException.class })
   public void delete(UUID id) throws UnauthorizedException, ResourceNotFoundException {
     StoreImage imageToDelete = findImageById(id);
+    Store store = imageToDelete.getStore();
     authService.assertUserOwnsStore(imageToDelete.getStore());
     storeImageRepository.delete(imageToDelete);
+
+    List<StoreImage> storeImages = storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(store.getId());
+
+    IntStream.range(0, storeImages.size())
+        .forEach(i -> {
+          StoreImage newStoreImage = storeImages.get(i);
+          newStoreImage.setDisplayOrder(i);
+          storeImageRepository.save(newStoreImage);
+        });
   }
 }

--- a/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
+++ b/src/main/java/ispp/project/dondesiempre/modules/stores/services/StoreImageService.java
@@ -14,7 +14,6 @@ import ispp.project.dondesiempre.utils.cloudinary.CloudinaryService;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
@@ -50,18 +49,20 @@ public class StoreImageService {
     return new StoreImageDTO(storeImage);
   }
 
-  @Transactional(rollbackFor = {
-      UnauthorizedException.class,
-      ResourceNotFoundException.class,
-      InvalidRequestException.class
-  })
+  @Transactional(
+      rollbackFor = {
+        UnauthorizedException.class,
+        ResourceNotFoundException.class,
+        InvalidRequestException.class
+      })
   public StoreImageDTO add(UUID id, StoreImageUpdateDTO dto, MultipartFile imageFile)
       throws UnauthorizedException, ResourceNotFoundException, InvalidRequestException {
 
     Store storeToUpdate = applicationContext.getBean(StoreService.class).findById(id);
     authService.assertUserOwnsStore(storeToUpdate);
 
-    List<StoreImage> existingImages = storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(id);
+    List<StoreImage> existingImages =
+        storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(id);
 
     if (existingImages.size() >= 5) {
       throw new InvalidRequestException("A store cannot have more than 5 images.");
@@ -79,7 +80,7 @@ public class StoreImageService {
     return toDTO(storeImageRepository.save(image));
   }
 
-  @Transactional(rollbackFor = { UnauthorizedException.class, ResourceNotFoundException.class })
+  @Transactional(rollbackFor = {UnauthorizedException.class, ResourceNotFoundException.class})
   public StoreImageDTO update(UUID imageId, StoreImageUpdateDTO dto)
       throws UnauthorizedException, ResourceNotFoundException {
 
@@ -92,20 +93,22 @@ public class StoreImageService {
     return toDTO(storeImageRepository.save(imageToUpdate));
   }
 
-  @Transactional(rollbackFor = { UnauthorizedException.class, ResourceNotFoundException.class })
+  @Transactional(rollbackFor = {UnauthorizedException.class, ResourceNotFoundException.class})
   public void delete(UUID id) throws UnauthorizedException, ResourceNotFoundException {
     StoreImage imageToDelete = findImageById(id);
     Store store = imageToDelete.getStore();
     authService.assertUserOwnsStore(imageToDelete.getStore());
     storeImageRepository.delete(imageToDelete);
 
-    List<StoreImage> storeImages = storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(store.getId());
+    List<StoreImage> storeImages =
+        storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(store.getId());
 
     IntStream.range(0, storeImages.size())
-        .forEach(i -> {
-          StoreImage newStoreImage = storeImages.get(i);
-          newStoreImage.setDisplayOrder(i);
-          storeImageRepository.save(newStoreImage);
-        });
+        .forEach(
+            i -> {
+              StoreImage newStoreImage = storeImages.get(i);
+              newStoreImage.setDisplayOrder(i);
+              storeImageRepository.save(newStoreImage);
+            });
   }
 }

--- a/src/test/java/ispp/project/dondesiempre/modules/stores/controllers/StoreImageControllerTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/stores/controllers/StoreImageControllerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -34,9 +34,11 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
 
 @WebMvcTest(
     controllers = StoreImageController.class,
@@ -117,25 +119,36 @@ class StoreImageControllerTest {
     requestDTO.setImage("https://example.com/new-image.jpg");
     requestDTO.setDisplayOrder(0);
 
+    MockMultipartFile dtoPart =
+        new MockMultipartFile(
+            "dto",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            objectMapper.writeValueAsBytes(requestDTO));
+
+    MockMultipartFile imagePart =
+        new MockMultipartFile(
+            "image", "test.jpg", MediaType.IMAGE_JPEG_VALUE, "fake-image-content".getBytes());
+
     StoreImageDTO responseDTO = new StoreImageDTO();
     responseDTO.setId(UUID.randomUUID());
     responseDTO.setImage("https://example.com/new-image.jpg");
     responseDTO.setDisplayOrder(0);
 
-    when(storeImageService.add(eq(storeId), any(StoreImageUpdateDTO.class)))
+    when(storeImageService.add(
+            eq(storeId), any(StoreImageUpdateDTO.class), any(MultipartFile.class)))
         .thenReturn(responseDTO);
 
     mockMvc
         .perform(
-            post("/api/v1/stores/{storeId}/images", storeId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(requestDTO)))
+            multipart("/api/v1/stores/{storeId}/images", storeId).file(dtoPart).file(imagePart))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id").value(responseDTO.getId().toString()))
         .andExpect(jsonPath("$.image").value("https://example.com/new-image.jpg"))
         .andExpect(jsonPath("$.displayOrder").value(0));
 
-    verify(storeImageService, times(1)).add(eq(storeId), any(StoreImageUpdateDTO.class));
+    verify(storeImageService, times(1))
+        .add(eq(storeId), any(StoreImageUpdateDTO.class), any(MultipartFile.class));
   }
 
   @Test
@@ -147,11 +160,20 @@ class StoreImageControllerTest {
     requestDTO.setImage("not-a-valid-url");
     requestDTO.setDisplayOrder(0);
 
+    MockMultipartFile dtoPart =
+        new MockMultipartFile(
+            "dto",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            objectMapper.writeValueAsBytes(requestDTO));
+
+    MockMultipartFile imagePart =
+        new MockMultipartFile(
+            "image", "test.jpg", MediaType.IMAGE_JPEG_VALUE, "fake-image-content".getBytes());
+
     mockMvc
         .perform(
-            post("/api/v1/stores/{storeId}/images", storeId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(requestDTO)))
+            multipart("/api/v1/stores/{storeId}/images", storeId).file(dtoPart).file(imagePart))
         .andExpect(status().isBadRequest());
   }
 
@@ -263,14 +285,24 @@ class StoreImageControllerTest {
     requestDTO.setImage("https://example.com/new-image.jpg");
     requestDTO.setDisplayOrder(4);
 
-    when(storeImageService.add(eq(storeId), any(StoreImageUpdateDTO.class)))
+    MockMultipartFile dtoPart =
+        new MockMultipartFile(
+            "dto",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            objectMapper.writeValueAsBytes(requestDTO));
+
+    MockMultipartFile imagePart =
+        new MockMultipartFile(
+            "image", "test.jpg", MediaType.IMAGE_JPEG_VALUE, "fake-image-content".getBytes());
+
+    when(storeImageService.add(
+            eq(storeId), any(StoreImageUpdateDTO.class), any(MultipartFile.class)))
         .thenThrow(new InvalidRequestException("A store cannot have more than 5 images."));
 
     mockMvc
         .perform(
-            post("/api/v1/stores/{storeId}/images", storeId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(requestDTO)))
+            multipart("/api/v1/stores/{storeId}/images", storeId).file(dtoPart).file(imagePart))
         .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreImageServiceTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreImageServiceTest.java
@@ -21,6 +21,7 @@ import ispp.project.dondesiempre.modules.stores.models.Store;
 import ispp.project.dondesiempre.modules.stores.models.StoreImage;
 import ispp.project.dondesiempre.modules.stores.repositories.StoreImageRepository;
 import ispp.project.dondesiempre.modules.stores.repositories.StoreRepository;
+import ispp.project.dondesiempre.utils.cloudinary.CloudinaryService;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -31,6 +32,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class StoreImageServiceTest {
@@ -40,6 +43,7 @@ class StoreImageServiceTest {
   @Mock private ApplicationContext applicationContext;
   @Mock private AuthService authService;
   @Mock private StoreService storeService;
+  @Mock private CloudinaryService cloudinaryService;
 
   @InjectMocks private StoreImageService storeImageService;
 
@@ -47,6 +51,7 @@ class StoreImageServiceTest {
   private StoreImage storeImage;
   private UUID storeId;
   private UUID imageId;
+  private MockMultipartFile imageFile;
 
   private StoreImage createStoreImageWithOrder(int order) {
     StoreImage image = new StoreImage();
@@ -75,6 +80,9 @@ class StoreImageServiceTest {
     storeImage.setStore(store);
     storeImage.setImage("https://example.com/image.jpg");
     storeImage.setDisplayOrder(0);
+
+    imageFile =
+        new MockMultipartFile("image", "test.jpg", "image/jpeg", "test image content".getBytes());
   }
 
   @Test
@@ -151,30 +159,33 @@ class StoreImageServiceTest {
   }
 
   @Test
-  void shouldAddImageSuccessfully() throws UnauthorizedException, ResourceNotFoundException {
+  void shouldAddImageSuccessfully()
+      throws UnauthorizedException, ResourceNotFoundException, InvalidRequestException {
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
-    dto.setImage("https://example.com/new-image.jpg");
     dto.setDisplayOrder(2);
 
     StoreImage savedImage = new StoreImage();
     savedImage.setId(UUID.randomUUID());
     savedImage.setStore(store);
-    savedImage.setImage(dto.getImage());
+    savedImage.setImage("https://example.com/new-image-from-cloudinary.jpg");
     savedImage.setDisplayOrder(dto.getDisplayOrder());
 
     when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
     when(storeService.findById(storeId)).thenReturn(store);
+    when(cloudinaryService.upload(any(MultipartFile.class)))
+        .thenReturn("https://example.com/new-image-from-cloudinary.jpg");
     when(storeImageRepository.save(any(StoreImage.class))).thenReturn(savedImage);
 
-    StoreImageDTO result = storeImageService.add(storeId, dto);
+    StoreImageDTO result = storeImageService.add(storeId, dto, imageFile);
 
     assertNotNull(result);
-    assertEquals("https://example.com/new-image.jpg", result.getImage());
+    assertEquals("https://example.com/new-image-from-cloudinary.jpg", result.getImage());
     assertEquals(2, result.getDisplayOrder());
 
     verify(applicationContext, times(1)).getBean(StoreService.class);
     verify(storeService, times(1)).findById(storeId);
     verify(authService, times(1)).assertUserOwnsStore(store);
+    verify(cloudinaryService, times(1)).upload(any(MultipartFile.class));
     verify(storeImageRepository, times(1)).save(any(StoreImage.class));
   }
 
@@ -182,14 +193,14 @@ class StoreImageServiceTest {
   void shouldThrowResourceNotFoundException_whenAddingImageToNonExistentStore()
       throws ResourceNotFoundException {
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
-    dto.setImage("https://example.com/new-image.jpg");
     dto.setDisplayOrder(0);
 
     when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
     when(storeService.findById(storeId))
         .thenThrow(new ResourceNotFoundException("Store not found"));
 
-    assertThrows(ResourceNotFoundException.class, () -> storeImageService.add(storeId, dto));
+    assertThrows(
+        ResourceNotFoundException.class, () -> storeImageService.add(storeId, dto, imageFile));
 
     verify(authService, never()).assertUserOwnsStore(any());
     verify(storeImageRepository, never()).save(any());
@@ -199,15 +210,57 @@ class StoreImageServiceTest {
   void shouldThrowUnauthorizedException_whenAddingImageWithoutOwnership()
       throws UnauthorizedException, ResourceNotFoundException {
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
-    dto.setImage("https://example.com/new-image.jpg");
     dto.setDisplayOrder(0);
 
     when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
     when(storeService.findById(storeId)).thenReturn(store);
     doThrow(new UnauthorizedException("Not owner")).when(authService).assertUserOwnsStore(store);
 
-    assertThrows(UnauthorizedException.class, () -> storeImageService.add(storeId, dto));
+    assertThrows(UnauthorizedException.class, () -> storeImageService.add(storeId, dto, imageFile));
 
+    verify(storeImageRepository, never()).save(any());
+  }
+
+  @Test
+  void shouldThrowInvalidRequestException_whenAddingMoreThanFiveImages()
+      throws UnauthorizedException, ResourceNotFoundException {
+
+    StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
+    dto.setDisplayOrder(4);
+
+    List<StoreImage> existingImages =
+        List.of(
+            createStoreImageWithOrder(0),
+            createStoreImageWithOrder(1),
+            createStoreImageWithOrder(2),
+            createStoreImageWithOrder(3),
+            createStoreImageWithOrder(4));
+
+    when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
+    when(storeService.findById(storeId)).thenReturn(store);
+    when(storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(storeId))
+        .thenReturn(existingImages);
+
+    assertThrows(
+        InvalidRequestException.class, () -> storeImageService.add(storeId, dto, imageFile));
+
+    verify(authService, times(1)).assertUserOwnsStore(store);
+    verify(storeImageRepository, never()).save(any());
+  }
+
+  @Test
+  void shouldThrowInvalidRequestException_whenAddingImageWithoutFile()
+      throws UnauthorizedException, ResourceNotFoundException {
+
+    StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
+    dto.setDisplayOrder(0);
+
+    when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
+    when(storeService.findById(storeId)).thenReturn(store);
+
+    assertThrows(InvalidRequestException.class, () -> storeImageService.add(storeId, dto, null));
+
+    verify(authService, times(1)).assertUserOwnsStore(store);
     verify(storeImageRepository, never()).save(any());
   }
 
@@ -295,32 +348,5 @@ class StoreImageServiceTest {
     assertThrows(UnauthorizedException.class, () -> storeImageService.delete(imageId));
 
     verify(storeImageRepository, never()).delete(any());
-  }
-
-  @Test
-  void shouldThrowInvalidRequestException_whenAddingMoreThanFiveImages()
-      throws UnauthorizedException, ResourceNotFoundException {
-
-    StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
-    dto.setImage("https://example.com/new-image.jpg");
-    dto.setDisplayOrder(4);
-
-    List<StoreImage> existingImages =
-        List.of(
-            createStoreImageWithOrder(0),
-            createStoreImageWithOrder(1),
-            createStoreImageWithOrder(2),
-            createStoreImageWithOrder(3),
-            createStoreImageWithOrder(4));
-
-    when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
-    when(storeService.findById(storeId)).thenReturn(store);
-    when(storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(storeId))
-        .thenReturn(existingImages);
-
-    assertThrows(InvalidRequestException.class, () -> storeImageService.add(storeId, dto));
-
-    verify(authService, times(1)).assertUserOwnsStore(store);
-    verify(storeImageRepository, never()).save(any());
   }
 }

--- a/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreImageServiceTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreImageServiceTest.java
@@ -162,13 +162,12 @@ class StoreImageServiceTest {
   void shouldAddImageSuccessfully()
       throws UnauthorizedException, ResourceNotFoundException, InvalidRequestException {
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
-    dto.setDisplayOrder(2);
 
     StoreImage savedImage = new StoreImage();
     savedImage.setId(UUID.randomUUID());
     savedImage.setStore(store);
     savedImage.setImage("https://example.com/new-image-from-cloudinary.jpg");
-    savedImage.setDisplayOrder(dto.getDisplayOrder());
+    savedImage.setDisplayOrder(2);
 
     List<StoreImage> existingImages =
         List.of(createStoreImageWithOrder(0), createStoreImageWithOrder(1));
@@ -198,7 +197,6 @@ class StoreImageServiceTest {
   void shouldThrowResourceNotFoundException_whenAddingImageToNonExistentStore()
       throws ResourceNotFoundException {
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
-    dto.setDisplayOrder(0);
 
     when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
     when(storeService.findById(storeId))
@@ -215,7 +213,6 @@ class StoreImageServiceTest {
   void shouldThrowUnauthorizedException_whenAddingImageWithoutOwnership()
       throws UnauthorizedException, ResourceNotFoundException {
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
-    dto.setDisplayOrder(0);
 
     when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
     when(storeService.findById(storeId)).thenReturn(store);
@@ -231,7 +228,6 @@ class StoreImageServiceTest {
       throws UnauthorizedException, ResourceNotFoundException {
 
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
-    dto.setDisplayOrder(4);
 
     List<StoreImage> existingImages =
         List.of(
@@ -258,7 +254,6 @@ class StoreImageServiceTest {
       throws UnauthorizedException, ResourceNotFoundException {
 
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
-    dto.setDisplayOrder(0);
 
     when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
     when(storeService.findById(storeId)).thenReturn(store);
@@ -274,20 +269,9 @@ class StoreImageServiceTest {
       throws UnauthorizedException, ResourceNotFoundException, InvalidRequestException {
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
     dto.setImage("https://example.com/updated-image.jpg");
-    dto.setDisplayOrder(3);
-
-    StoreImage targetSwapImage = createStoreImageWithOrder(3);
-
-    List<StoreImage> existingImages =
-        List.of(
-            storeImage,
-            createStoreImageWithOrder(1),
-            createStoreImageWithOrder(2),
-            targetSwapImage);
+    dto.setDisplayOrder(1);
 
     when(storeImageRepository.findById(imageId)).thenReturn(Optional.of(storeImage));
-    when(storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(storeId))
-        .thenReturn(existingImages);
     when(storeImageRepository.save(any(StoreImage.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -295,14 +279,11 @@ class StoreImageServiceTest {
 
     assertNotNull(result);
     assertEquals("https://example.com/updated-image.jpg", result.getImage());
-    assertEquals(3, result.getDisplayOrder());
-
-    assertEquals(0, targetSwapImage.getDisplayOrder());
+    assertEquals(1, result.getDisplayOrder());
 
     verify(storeImageRepository, times(1)).findById(imageId);
     verify(authService, times(1)).assertUserOwnsStore(store);
     verify(storeImageRepository, times(1)).save(storeImage);
-    verify(storeImageRepository, times(1)).save(targetSwapImage);
   }
 
   @Test

--- a/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreImageServiceTest.java
+++ b/src/test/java/ispp/project/dondesiempre/modules/stores/services/StoreImageServiceTest.java
@@ -170,8 +170,13 @@ class StoreImageServiceTest {
     savedImage.setImage("https://example.com/new-image-from-cloudinary.jpg");
     savedImage.setDisplayOrder(dto.getDisplayOrder());
 
+    List<StoreImage> existingImages =
+        List.of(createStoreImageWithOrder(0), createStoreImageWithOrder(1));
+
     when(applicationContext.getBean(StoreService.class)).thenReturn(storeService);
     when(storeService.findById(storeId)).thenReturn(store);
+    when(storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(storeId))
+        .thenReturn(existingImages);
     when(cloudinaryService.upload(any(MultipartFile.class)))
         .thenReturn("https://example.com/new-image-from-cloudinary.jpg");
     when(storeImageRepository.save(any(StoreImage.class))).thenReturn(savedImage);
@@ -265,25 +270,39 @@ class StoreImageServiceTest {
   }
 
   @Test
-  void shouldUpdateImageSuccessfully() throws UnauthorizedException, ResourceNotFoundException {
+  void shouldUpdateImageSuccessfully()
+      throws UnauthorizedException, ResourceNotFoundException, InvalidRequestException {
     StoreImageUpdateDTO dto = new StoreImageUpdateDTO();
     dto.setImage("https://example.com/updated-image.jpg");
     dto.setDisplayOrder(3);
 
+    StoreImage targetSwapImage = createStoreImageWithOrder(3);
+
+    List<StoreImage> existingImages =
+        List.of(
+            storeImage,
+            createStoreImageWithOrder(1),
+            createStoreImageWithOrder(2),
+            targetSwapImage);
+
     when(storeImageRepository.findById(imageId)).thenReturn(Optional.of(storeImage));
-    when(storeImageRepository.save(storeImage)).thenReturn(storeImage);
+    when(storeImageRepository.findImagesByStoreIdOrderByDisplayOrder(storeId))
+        .thenReturn(existingImages);
+    when(storeImageRepository.save(any(StoreImage.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
 
     StoreImageDTO result = storeImageService.update(imageId, dto);
 
     assertNotNull(result);
     assertEquals("https://example.com/updated-image.jpg", result.getImage());
     assertEquals(3, result.getDisplayOrder());
-    assertEquals("https://example.com/updated-image.jpg", storeImage.getImage().orElse(null));
-    assertEquals(3, storeImage.getDisplayOrder());
+
+    assertEquals(0, targetSwapImage.getDisplayOrder());
 
     verify(storeImageRepository, times(1)).findById(imageId);
     verify(authService, times(1)).assertUserOwnsStore(store);
     verify(storeImageRepository, times(1)).save(storeImage);
+    verify(storeImageRepository, times(1)).save(targetSwapImage);
   }
 
   @Test


### PR DESCRIPTION
# Backend Pull Request

## Description

PR CON SU CORRESPONDIENTE PR DE FRONTEND

Se ha refactorizado la lógica de creación de imágenes para las tiendas (`StoreImage`) para conectarla con el servicio de almacenamiento en la nube (Cloudinary), replicando el comportamiento existente en la entidad `Product`.

**Cambios principales:**
* **Controlador (`StoreImageController`)**: El endpoint `POST /api/v1/stores/{storeId}/images` ahora consume `multipart/form-data`. Recibe el `StoreImageUpdateDTO` y un `MultipartFile`.
* **Servicio (`StoreImageService`)**: Se ha inyectado `CloudinaryService`. Ahora el servicio sube el archivo a Cloudinary y almacena la URL pública devuelta en la base de datos. Se han mantenido las validaciones de propiedad y el límite máximo de 5 imágenes.
* **Excepciones (`GlobalExceptionHandler`)**: Se ha añadido la captura de `MaxUploadSizeExceededException` para devolver de forma semántica un error HTTP 413 (Payload Too Large) cuando el archivo supera el límite de Spring Boot, evitando así errores 500 no controlados.
* **Testing**: Se han actualizado por completo `StoreImageControllerTest` y `StoreImageServiceTest` utilizando `MockMultipartFile` y mockeando `CloudinaryService` para asegurar una cobertura total.

---

## Type of Change

- [ ] New endpoint
- [ ] Bug fix
- [x] Refactor
- [ ] Performance improvement

---

## Database Changes (if applicable)

- [ ] Migration added
- [ ] Schema updated
- [ ] Seed updated
*(Ninguno. La base de datos ya estaba preparada para recibir la URL como un `String`)*

---

## Checklist

- [x] I made sure tests are passing locally
- [x] I handled error cases
- [x] I followed the style guides
- [x] I followed the Controller-Service-Repository pattern
- [x] I tested my code


> Recuerda revisar que la notificación de la pull request llega a Discord en el canal de #github