### PR TITLE
fix: added exception for payload_too_large for image handling

### DIFF
--- a/src/main/java/ispp/project/dondesiempre/config/GlobalExceptionHandler.java
+++ b/src/main/java/ispp/project/dondesiempre/config/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -64,6 +65,13 @@ public class GlobalExceptionHandler {
   public ResponseEntity<String> handleStripeException(
       StripeException exception, WebRequest request) {
     return new ResponseEntity<>(exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<String> handleMaxSizeException(
+      MaxUploadSizeExceededException exception, WebRequest request) {
+    return new ResponseEntity<>(exception.getMessage(), HttpStatus.PAYLOAD_TOO_LARGE);
   }
 
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
# Backend Pull Request

## Description

Se ha implementado el manejo específico de la excepción MaxUploadSizeExceededException en el GlobalExceptionHandler.

Anteriormente, cuando un cliente intentaba crear o actualizar una entidad (como promociones o productos) adjuntando una imagen que superaba el límite máximo de tamaño configurado en el servidor, la petición fallaba devolviendo un error HTTP 500 (Internal Server Error) genérico.

---

## Type of Change

- [ ] New endpoint
- [x] Bug fix
- [ ] Refactor
- [ ] Performance improvement

---

## Database Changes (if applicable)

- [ ] Migration added
- [ ] Schema updated
- [ ] Seed updated

---

## Checklist

- [x] I made sure tests are passing locally
- [x] I handled error cases
- [x] I followed the style guides
- [x] I followed the Controller-Service-Repository pattern
- [x] I tested my code